### PR TITLE
feat: add quiz results page with career insights and redirect flow

### DIFF
--- a/assets/css/quiz-results.css
+++ b/assets/css/quiz-results.css
@@ -1,0 +1,579 @@
+/* ═══════════════════════════════════════════════════
+   quiz-results.css  —  PathwayAI Career Results Page
+   ═══════════════════════════════════════════════════ */
+
+/* ── CANVAS BACKGROUND ── */
+#particles-canvas {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.45;
+}
+
+/* ── PAGE SHELL ── */
+.results-page {
+  position: relative;
+  z-index: 1;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 100px 24px 80px;
+}
+
+/* ── SHARED SECTION LABELS ── */
+.section-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gold);
+  background: rgba(212,175,55,0.07);
+  border: 1px solid rgba(212,175,55,0.18);
+  padding: 5px 12px;
+  border-radius: 20px;
+  margin-bottom: 16px;
+}
+
+.section-title {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+.section-title em { font-style: italic; color: var(--gold); }
+
+.section-sub {
+  font-size: 15px;
+  color: var(--muted);
+  line-height: 1.7;
+  max-width: 520px;
+  margin-bottom: 48px;
+}
+
+/* ════════════════════════════════
+   HERO
+════════════════════════════════ */
+.results-hero {
+  text-align: center;
+  padding: 0 0 80px;
+  position: relative;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeUp 0.7s 0.1s ease forwards;
+}
+
+.hero-glow-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 600px;
+  height: 600px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(212,175,55,0.04) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  color: var(--gold);
+  background: rgba(212,175,55,0.06);
+  border: 1px solid rgba(212,175,55,0.2);
+  padding: 6px 14px;
+  border-radius: 20px;
+  margin-bottom: 28px;
+}
+.hero-badge svg { width: 13px; height: 13px; stroke: var(--gold); }
+
+.hero-title {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(32px, 5vw, 58px);
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.02em;
+  margin-bottom: 14px;
+  line-height: 1.15;
+}
+.hero-title em { font-style: italic; color: var(--gold); }
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--muted);
+  line-height: 1.7;
+  max-width: 500px;
+  margin: 0 auto 48px;
+}
+
+/* ── MATCH RING ── */
+.match-ring-wrap {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto 32px;
+}
+.match-ring-svg {
+  width: 200px;
+  height: 200px;
+  filter: drop-shadow(0 0 18px rgba(212,175,55,0.22));
+}
+.match-ring-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+.match-pct {
+  font-family: 'Playfair Display', serif;
+  font-size: 38px;
+  font-weight: 600;
+  color: var(--gold);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.match-label {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* ── TOP CAREER PILL ── */
+.top-career-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--card);
+  border: 1px solid var(--border-g);
+  border-radius: 50px;
+  padding: 12px 22px;
+  opacity: 0;
+  transform: translateY(12px);
+  animation: fadeUp 0.5s 1s ease forwards;
+}
+.pill-icon { font-size: 22px; line-height: 1; }
+.pill-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+.pill-tag {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gold);
+  background: rgba(212,175,55,0.08);
+  border: 1px solid rgba(212,175,55,0.18);
+  padding: 3px 9px;
+  border-radius: 10px;
+}
+
+/* ════════════════════════════════
+   CAREER CARDS
+════════════════════════════════ */
+.careers-section {
+  padding: 0 0 80px;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeUp 0.7s 0.3s ease forwards;
+}
+
+.careers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.career-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 28px 24px;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.2s, background 0.2s;
+  position: relative;
+  overflow: hidden;
+  animation: cardIn 0.5s ease both;
+}
+.career-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(212,175,55,0.15), transparent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.career-card:hover { border-color: var(--border-g); background: #141414; transform: translateY(-4px); }
+.career-card:hover::before { opacity: 1; }
+
+.career-card.primary {
+  border-color: rgba(212,175,55,0.35);
+  background: linear-gradient(135deg, rgba(212,175,55,0.06) 0%, var(--card) 60%);
+}
+.career-card.primary::before { opacity: 1; }
+
+.card-rank {
+  position: absolute;
+  top: 14px; right: 14px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 3px 8px;
+  border-radius: 6px;
+}
+.career-card.primary .card-rank {
+  color: var(--gold);
+  background: rgba(212,175,55,0.08);
+  border-color: rgba(212,175,55,0.2);
+}
+
+.card-icon { font-size: 32px; line-height: 1; margin-bottom: 14px; }
+.card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 16px;
+}
+
+.card-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.card-bar-bg {
+  flex: 1;
+  height: 5px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.card-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #D4AF37, #F5D060);
+  width: 0%;
+  transition: width 1.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.career-card.primary .card-bar-fill {
+  background: linear-gradient(90deg, #D4AF37, #fff0a0);
+  box-shadow: 0 0 8px rgba(212,175,55,0.4);
+}
+.card-pct {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gold);
+  min-width: 44px;
+  text-align: right;
+}
+
+.card-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.card-tag {
+  font-size: 11px;
+  color: var(--muted);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  padding: 3px 8px;
+  border-radius: 5px;
+}
+
+/* ════════════════════════════════
+   3D ECOSYSTEM CANVAS
+════════════════════════════════ */
+.ecosystem-section {
+  padding: 0 0 80px;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeUp 0.7s 0.5s ease forwards;
+}
+
+.ecosystem-wrap {
+  position: relative;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  overflow: hidden;
+  height: 480px;
+}
+#ecosystem-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: grab;
+}
+#ecosystem-canvas:active { cursor: grabbing; }
+
+.ecosystem-legend {
+  position: absolute;
+  bottom: 20px;
+  left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.legend-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.dot-career { background: #D4AF37; box-shadow: 0 0 6px rgba(212,175,55,0.6); }
+.dot-skill  { background: rgba(100,180,255,0.8); box-shadow: 0 0 6px rgba(100,180,255,0.4); }
+.dot-center { background: #fff; box-shadow: 0 0 10px rgba(255,255,255,0.5); }
+
+.ecosystem-hint {
+  position: absolute;
+  bottom: 20px;
+  right: 24px;
+  font-size: 11px;
+  color: var(--subtle, rgba(255,255,255,0.25));
+  letter-spacing: 0.04em;
+}
+
+/* ════════════════════════════════
+   STATS
+════════════════════════════════ */
+.stats-section {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 80px;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeUp 0.7s 0.6s ease forwards;
+}
+@media (max-width: 700px) { .stats-section { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 420px) { .stats-section { grid-template-columns: 1fr; } }
+
+.stat-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px 20px;
+  text-align: center;
+  transition: border-color 0.2s, transform 0.2s;
+}
+.stat-card:hover { border-color: rgba(212,175,55,0.2); transform: translateY(-3px); }
+
+.stat-icon {
+  width: 40px; height: 40px;
+  border-radius: 10px;
+  background: rgba(212,175,55,0.07);
+  border: 1px solid rgba(212,175,55,0.15);
+  display: grid;
+  place-items: center;
+  margin: 0 auto 14px;
+}
+.stat-icon svg { width: 18px; height: 18px; stroke: var(--gold); }
+.stat-value {
+  font-family: 'Playfair Display', serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+.stat-name {
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.03em;
+}
+
+/* ════════════════════════════════
+   SKILLS
+════════════════════════════════ */
+.skills-section {
+  margin-bottom: 80px;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeUp 0.7s 0.7s ease forwards;
+}
+
+.skills-inner {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 48px;
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 60px;
+  align-items: center;
+}
+@media (max-width: 720px) {
+  .skills-inner { grid-template-columns: 1fr; gap: 32px; padding: 32px 24px; }
+}
+
+.skill-bars { display: flex; flex-direction: column; gap: 20px; }
+
+.skill-row { display: flex; flex-direction: column; gap: 8px; }
+.skill-row-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.skill-name { font-size: 14px; font-weight: 500; color: var(--text); }
+.skill-pct  { font-size: 13px; color: var(--gold); font-weight: 600; }
+
+.skill-track {
+  height: 6px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.skill-fill {
+  height: 100%;
+  border-radius: 3px;
+  width: 0%;
+  transition: width 1.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.skill-fill.high   { background: linear-gradient(90deg, #D4AF37, #F5D060); }
+.skill-fill.medium { background: linear-gradient(90deg, #60a5fa, #93c5fd); }
+.skill-fill.low    { background: linear-gradient(90deg, #f87171, #fca5a5); }
+
+/* ════════════════════════════════
+   CTA
+════════════════════════════════ */
+.cta-section {
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeUp 0.7s 0.8s ease forwards;
+}
+
+.cta-card {
+  background: var(--card);
+  border: 1px solid rgba(212,175,55,0.2);
+  border-radius: 24px;
+  padding: 64px 40px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.cta-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(212,175,55,0.4), transparent);
+}
+
+.cta-glow {
+  position: absolute;
+  bottom: -120px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 500px;
+  height: 300px;
+  background: radial-gradient(ellipse, rgba(212,175,55,0.07) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.cta-icon {
+  width: 60px; height: 60px;
+  border-radius: 50%;
+  background: rgba(212,175,55,0.08);
+  border: 1px solid rgba(212,175,55,0.22);
+  display: grid;
+  place-items: center;
+  margin: 0 auto 24px;
+}
+.cta-icon svg { width: 26px; height: 26px; stroke: var(--gold); }
+
+.cta-title {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(24px, 4vw, 38px);
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 12px;
+}
+.cta-sub {
+  font-size: 15px;
+  color: var(--muted);
+  max-width: 440px;
+  margin: 0 auto 36px;
+  line-height: 1.7;
+}
+
+.cta-btns {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+/* Re-use existing button classes from styles.css */
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 12px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+}
+.btn-outline:hover { border-color: var(--border-g); background: rgba(255,255,255,0.03); }
+
+/* ── TOAST ── */
+.toast {
+  position: fixed;
+  bottom: 32px; left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: #1a1a1a;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 14px;
+  color: var(--text);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s, transform 0.3s;
+  z-index: 9999;
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ── ANIMATIONS ── */
+@keyframes fadeUp {
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes cardIn {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── RESPONSIVE ── */
+@media (max-width: 600px) {
+  .results-page { padding: 80px 16px 60px; }
+  .top-career-pill { flex-wrap: wrap; justify-content: center; }
+  .careers-grid { grid-template-columns: 1fr; }
+  .cta-card { padding: 40px 24px; }
+  .ecosystem-wrap { height: 320px; }
+}

--- a/assets/js/quiz-assessment.js
+++ b/assets/js/quiz-assessment.js
@@ -1,46 +1,185 @@
 const questions = [
-  { type:"radio", text:"What type of work environment energizes you the most?", options:["Collaborative team environment","Independent remote work","Dynamic startup atmosphere","Structured corporate setting"] },
-  { type:"slider", text:"How much do you enjoy solving complex problems?", min:1, max:10, default:5, labels:["1 (Low)","10 (High)"] },
-  { type:"checkbox", text:"Which activities do you find most engaging?", hint:"Select all that apply:", options:["Creating and designing","Analyzing data and patterns","Leading and managing teams","Building and coding","Teaching and mentoring","Researching and exploring"] },
-  { type:"slider", text:"Rate your communication and presentation skills", min:1, max:10, default:5, labels:["1 (Low)","10 (High)"] },
-  { type:"checkbox", text:"What aspects of work give you the most satisfaction?", hint:"Select all that apply:", options:["Making a positive impact","Learning new things","Earning good money","Having flexibility","Being recognized","Working with technology"] },
-  { type:"radio", text:"Which subject area excites you the most?", options:["Technology & Engineering","Business & Finance","Arts & Design","Science & Research"] },
-  { type:"slider", text:"How comfortable are you with taking risks and uncertainty?", min:1, max:10, default:5, labels:["1 (Low)","10 (High)"] },
-  { type:"radio", text:"Where do you see yourself in 5 years?", options:["Leading a team or company","Deep technical expert","Creative director or designer","Researcher or academic"] }
+  { type:"radio",    text:"What type of work environment energizes you the most?",    options:["Collaborative team environment","Independent remote work","Dynamic startup atmosphere","Structured corporate setting"] },
+  { type:"slider",   text:"How much do you enjoy solving complex problems?",           min:1, max:10, default:5, labels:["1 (Low)","10 (High)"] },
+  { type:"checkbox", text:"Which activities do you find most engaging?",               hint:"Select all that apply:", options:["Creating and designing","Analyzing data and patterns","Leading and managing teams","Building and coding","Teaching and mentoring","Researching and exploring"] },
+  { type:"slider",   text:"Rate your communication and presentation skills",           min:1, max:10, default:5, labels:["1 (Low)","10 (High)"] },
+  { type:"checkbox", text:"What aspects of work give you the most satisfaction?",     hint:"Select all that apply:", options:["Making a positive impact","Learning new things","Earning good money","Having flexibility","Being recognized","Working with technology"] },
+  { type:"radio",    text:"Which subject area excites you the most?",                  options:["Technology & Engineering","Business & Finance","Arts & Design","Science & Research"] },
+  { type:"slider",   text:"How comfortable are you with taking risks and uncertainty?",min:1, max:10, default:5, labels:["1 (Low)","10 (High)"] },
+  { type:"radio",    text:"Where do you see yourself in 5 years?",                    options:["Leading a team or company","Deep technical expert","Creative director or designer","Researcher or academic"] }
 ];
 
 let current = 0;
 const answers = new Array(questions.length).fill(null);
 
+// ─────────────────────────────────────────────
+// SCORING ENGINE
+// Each career has per-question signal rules.
+// Points accumulate; final score is normalized
+// to a 40–99 range so results always look
+// meaningful rather than 0% / 100%.
+// ─────────────────────────────────────────────
+
+const CAREER_SIGNALS = {
+  "Frontend Engineer": {
+    // Q0 radio: startup(2) or remote(1) preferred
+    q0: { type:"radio", points:{ 0:1, 1:2, 2:3, 3:0 } },
+    // Q1 slider: solving complex problems matters
+    q1: { type:"slider", weight: 1.2 },
+    // Q2 checkbox: "Building and coding"(idx 3), "Creating and designing"(idx 0)
+    q2: { type:"checkbox", bonusIdxs:[3,0], bonusPer:3 },
+    // Q3 slider: communication matters less
+    q3: { type:"slider", weight: 0.4 },
+    // Q4 checkbox: "Working with technology"(idx 5), "Learning new things"(idx 1)
+    q4: { type:"checkbox", bonusIdxs:[5,1], bonusPer:3 },
+    // Q5 radio: Technology(0) is perfect
+    q5: { type:"radio", points:{ 0:5, 1:1, 2:2, 3:0 } },
+    // Q6 slider: risk tolerance moderate
+    q6: { type:"slider", weight: 0.7 },
+    // Q7 radio: deep technical expert(1) or creative(2)
+    q7: { type:"radio", points:{ 0:1, 1:5, 2:3, 3:0 } }
+  },
+
+  "Product Designer": {
+    q0: { type:"radio", points:{ 0:2, 1:1, 2:3, 3:0 } },
+    q1: { type:"slider", weight: 0.6 },
+    // "Creating and designing"(0), "Leading and managing teams"(2)
+    q2: { type:"checkbox", bonusIdxs:[0,2], bonusPer:3 },
+    q3: { type:"slider", weight: 1.2 },
+    // "Making a positive impact"(0), "Being recognized"(4)
+    q4: { type:"checkbox", bonusIdxs:[0,4], bonusPer:3 },
+    q5: { type:"radio", points:{ 0:2, 1:1, 2:5, 3:0 } },
+    q6: { type:"slider", weight: 0.8 },
+    q7: { type:"radio", points:{ 0:2, 1:1, 2:5, 3:0 } }
+  },
+
+  "Data Analyst": {
+    q0: { type:"radio", points:{ 0:1, 1:3, 2:1, 3:2 } },
+    q1: { type:"slider", weight: 1.5 },
+    // "Analyzing data and patterns"(1), "Researching and exploring"(5)
+    q2: { type:"checkbox", bonusIdxs:[1,5], bonusPer:3 },
+    q3: { type:"slider", weight: 0.5 },
+    // "Learning new things"(1), "Earning good money"(2)
+    q4: { type:"checkbox", bonusIdxs:[1,2], bonusPer:3 },
+    q5: { type:"radio", points:{ 0:1, 1:2, 2:0, 3:5 } },
+    q6: { type:"slider", weight: 0.6 },
+    q7: { type:"radio", points:{ 0:0, 1:3, 2:0, 3:5 } }
+  },
+
+  "Backend Developer": {
+    q0: { type:"radio", points:{ 0:1, 1:3, 2:2, 3:2 } },
+    q1: { type:"slider", weight: 1.4 },
+    // "Building and coding"(3), "Analyzing data and patterns"(1)
+    q2: { type:"checkbox", bonusIdxs:[3,1], bonusPer:3 },
+    q3: { type:"slider", weight: 0.3 },
+    // "Working with technology"(5), "Earning good money"(2)
+    q4: { type:"checkbox", bonusIdxs:[5,2], bonusPer:3 },
+    q5: { type:"radio", points:{ 0:4, 1:1, 2:0, 3:2 } },
+    q6: { type:"slider", weight: 0.9 },
+    q7: { type:"radio", points:{ 0:2, 1:5, 2:0, 3:1 } }
+  }
+};
+
+function calcCareerScore(careerKey) {
+  const signals = CAREER_SIGNALS[careerKey];
+  let total = 0;
+  let maxPossible = 0;
+
+  answers.forEach((ans, i) => {
+    const key = "q" + i;
+    const sig = signals[key];
+    if (!sig) return;
+    const q = questions[i];
+
+    if (sig.type === "slider") {
+      const val = (ans !== null ? ans : q.default);
+      total      += val * sig.weight;
+      maxPossible += 10 * sig.weight;
+
+    } else if (sig.type === "radio") {
+      if (ans !== null) {
+        total      += sig.points[ans] || 0;
+        maxPossible += Math.max(...Object.values(sig.points));
+      } else {
+        maxPossible += Math.max(...Object.values(sig.points));
+      }
+
+    } else if (sig.type === "checkbox") {
+      const selected = Array.isArray(ans) ? ans : [];
+      const matches  = selected.filter(idx => sig.bonusIdxs.includes(idx)).length;
+      total      += matches * sig.bonusPer;
+      maxPossible += sig.bonusIdxs.length * sig.bonusPer;
+    }
+  });
+
+  if (maxPossible === 0) return 50;
+
+  // Normalize to 40–99 range so it always looks meaningful
+  const raw = total / maxPossible;        // 0.0 → 1.0
+  return Math.round(40 + raw * 59);       // 40 → 99
+}
+
+function showResult() {
+  document.getElementById("quiz-topbar").style.display  = "none";
+  document.getElementById("progress-wrap").style.display = "none";
+
+  // Calculate real scores for each career
+  const careerScores = Object.keys(CAREER_SIGNALS)
+    .map(name => ({ name, score: calcCareerScore(name) }))
+    .sort((a, b) => b.score - a.score);   // highest first
+
+  // Persist for quiz-results.html to read
+  localStorage.setItem("quizCareerScores", JSON.stringify(careerScores));
+  localStorage.setItem("quizAnswers",       JSON.stringify(answers));
+
+  // Navigate to results page (same folder as quiz-assessment.html)
+  window.location.href = "quiz-results.html";
+}
+
+// ─────────────────────────────────────────────
+// RENDER ENGINE  (unchanged from original)
+// ─────────────────────────────────────────────
 function render() {
   if (current >= questions.length) { showResult(); return; }
   const q = questions[current];
-  const displayPct = Math.max(13, Math.round(((current+1)/questions.length)*100));
-  document.getElementById("q-counter").textContent = "Question "+(current+1)+" of "+questions.length;
-  document.getElementById("q-percent").textContent = displayPct+"% Complete";
-  document.getElementById("progress-fill").style.width = displayPct+"%";
-  let html = "<div class='q-text'>"+q.text+"</div>";
-  if (q.hint) html += "<div class='q-hint'>"+q.hint+"</div>";
+  const displayPct = Math.max(13, Math.round(((current + 1) / questions.length) * 100));
+
+  document.getElementById("q-counter").textContent        = "Question " + (current + 1) + " of " + questions.length;
+  document.getElementById("q-percent").textContent        = displayPct + "% Complete";
+  document.getElementById("progress-fill").style.width    = displayPct + "%";
+
+  let html = "<div class='q-text'>" + q.text + "</div>";
+  if (q.hint) html += "<div class='q-hint'>" + q.hint + "</div>";
+
   if (q.type === "radio") {
     html += "<div class='options-grid'>";
-    q.options.forEach((opt,i) => {
-      const sel = answers[current]===i?"selected":"";
-      html += "<label class='opt-label "+sel+"' onclick='selectRadio("+i+",this)'><div class='opt-circle'><div class='opt-circle-inner'></div></div>"+opt+"</label>";
+    q.options.forEach((opt, i) => {
+      const sel = answers[current] === i ? "selected" : "";
+      html += "<label class='opt-label " + sel + "' onclick='selectRadio(" + i + ",this)'><div class='opt-circle'><div class='opt-circle-inner'></div></div>" + opt + "</label>";
     });
     html += "</div>";
+
   } else if (q.type === "checkbox") {
-    const saved = Array.isArray(answers[current])?answers[current]:[];
+    const saved = Array.isArray(answers[current]) ? answers[current] : [];
     html += "<div class='options-grid'>";
-    q.options.forEach((opt,i) => {
-      const sel = saved.includes(i)?"selected":"";
-      html += "<label class='opt-label "+sel+"' onclick='toggleCheck("+i+",this)'><div class='opt-square'><svg viewBox='0 0 24 24'><polyline points='20 6 9 17 4 12'/></svg></div>"+opt+"</label>";
+    q.options.forEach((opt, i) => {
+      const sel = saved.includes(i) ? "selected" : "";
+      html += "<label class='opt-label " + sel + "' onclick='toggleCheck(" + i + ",this)'><div class='opt-square'><svg viewBox='0 0 24 24'><polyline points='20 6 9 17 4 12'/></svg></div>" + opt + "</label>";
     });
     html += "</div>";
+
   } else if (q.type === "slider") {
-    const val = answers[current]!==null?answers[current]:q.default;
-    html += "<div class='slider-wrap'><input type='range' class='quiz-slider' id='quiz-slider' min='"+q.min+"' max='"+q.max+"' value='"+val+"' oninput='updateSlider(this.value)'/><div class='slider-labels'><span>"+q.labels[0]+"</span><span>"+q.labels[1]+"</span></div><div class='slider-val' id='slider-display'>"+val+"</div></div>";
+    const val = answers[current] !== null ? answers[current] : q.default;
+    html += "<div class='slider-wrap'><input type='range' class='quiz-slider' id='quiz-slider' min='" + q.min + "' max='" + q.max + "' value='" + val + "' oninput='updateSlider(this.value)'/><div class='slider-labels'><span>" + q.labels[0] + "</span><span>" + q.labels[1] + "</span></div><div class='slider-val' id='slider-display'>" + val + "</div></div>";
   }
-  document.getElementById("quiz-body").innerHTML = "<div class='q-card'>"+html+"</div><div class='quiz-nav'><button class='quiz-back-btn' onclick='goBack()' "+(current===0?"disabled":"")+">← Previous</button><button class='quiz-next-btn' onclick='goNext()'>"+(current===questions.length-1?"See Results":"Next")+" →</button></div><div class='quiz-hub-link'>← <a href='quiz.html'>Back to Quiz Hub</a></div>";
+
+  document.getElementById("quiz-body").innerHTML =
+    "<div class='q-card'>" + html + "</div>" +
+    "<div class='quiz-nav'>" +
+      "<button class='quiz-back-btn' onclick='goBack()' " + (current === 0 ? "disabled" : "") + ">← Previous</button>" +
+      "<button class='quiz-next-btn' onclick='goNext()'>" + (current === questions.length - 1 ? "See Results" : "Next") + " →</button>" +
+    "</div>" +
+    "<div class='quiz-hub-link'>← <a href='quiz.html'>Back to Quiz Hub</a></div>";
 }
 
 function selectRadio(i, el) {
@@ -53,7 +192,7 @@ function toggleCheck(i, el) {
   if (!Array.isArray(answers[current])) answers[current] = [];
   const idx = answers[current].indexOf(i);
   if (idx === -1) { answers[current].push(i); el.classList.add("selected"); }
-  else { answers[current].splice(idx, 1); el.classList.remove("selected"); }
+  else            { answers[current].splice(idx, 1); el.classList.remove("selected"); }
 }
 
 function updateSlider(val) {
@@ -64,7 +203,7 @@ function updateSlider(val) {
 function goNext() {
   const q = questions[current];
   if (q.type === "slider" && answers[current] === null) answers[current] = q.default;
-  if (q.type === "radio" && answers[current] === null) { showToast("Please select an option to continue"); return; }
+  if (q.type === "radio"  && answers[current] === null) { showToast("Please select an option to continue"); return; }
   current++;
   render();
 }
@@ -73,24 +212,12 @@ function goBack() {
   if (current > 0) { current--; render(); }
 }
 
-function showResult() {
-  document.getElementById("quiz-topbar").style.display = "none";
-  document.getElementById("progress-wrap").style.display = "none";
-  const careers = [
-    {icon:"💻", name:"Frontend Engineer",  score:91},
-    {icon:"🎨", name:"Product Designer",   score:78},
-    {icon:"📊", name:"Data Analyst",       score:63},
-    {icon:"⚙️", name:"Backend Developer",  score:54}
-  ];
-  let rows = "";
-  careers.forEach(c => {
-    rows += "<div class='result-career-row'><div class='result-career-icon'>"+c.icon+"</div><div class='result-career-name'>"+c.name+"</div><div class='result-career-bar-wrap'><div class='result-career-bar-bg'><div class='result-career-bar-fill' style='width:"+c.score+"%'></div></div><div class='result-career-pct'>"+c.score+"% match</div></div></div>";
-  });
-  const isLoggedIn = !!localStorage.getItem("userEmail");
-  const dashBtn = isLoggedIn
-    ? "<a href='dashboard.html'><button class='btn-primary' style='padding:12px 24px;font-size:14px'>View Full Dashboard →</button></a>"
-    : "<a href='login.html'><button class='btn-primary' style='padding:12px 24px;font-size:14px'>Sign in to save results →</button></a>";
-  document.getElementById("quiz-body").innerHTML = "<div class='result-card'><div class='result-trophy'>🎯</div><div class='result-title'>Your Best <em>Career Matches</em></div><div class='result-sub'>Based on your answers — here are your top career paths</div><div class='result-careers'>"+rows+"</div><div class='result-btns'>"+dashBtn+"<a href='quiz.html'><button class='btn-outline' style='padding:11px 22px;font-size:14px'>Retake Quiz</button></a></div></div><div class='quiz-hub-link' style='margin-top:20px'>← <a href='quiz.html'>Back to Quiz Hub</a></div>";
+function showToast(msg) {
+  const t = document.getElementById("toast");
+  if (!t) return;
+  t.textContent = msg;
+  t.classList.add("show");
+  setTimeout(() => t.classList.remove("show"), 2800);
 }
 
 render();

--- a/assets/js/quiz-results.js
+++ b/assets/js/quiz-results.js
@@ -1,0 +1,503 @@
+/* ═══════════════════════════════════════════════════
+   quiz-results.js  —  PathwayAI Career Results Page
+   ═══════════════════════════════════════════════════ */
+
+// ── CAREER DATA MAP ──
+const CAREER_DATA = {
+  "Frontend Engineer": {
+    icon: "💻", score: 91,
+    tags: ["React", "CSS", "JavaScript"],
+    salary: "$68k – $120k", growth: "22% Growth", demand: "Very High",
+    skills: [
+      { name: "JavaScript / TypeScript", pct: 85, level: "high" },
+      { name: "React / Vue", pct: 72, level: "high" },
+      { name: "UI/UX Design", pct: 55, level: "medium" },
+      { name: "System Design", pct: 38, level: "low" },
+      { name: "Testing & CI/CD", pct: 45, level: "medium" }
+    ],
+    nodes: ["React", "Node.js", "CSS", "TypeScript", "UI Design", "REST APIs", "Git"]
+  },
+  "Product Designer": {
+    icon: "🎨", score: 78,
+    tags: ["Figma", "UX", "Prototyping"],
+    salary: "$60k – $110k", growth: "18% Growth", demand: "High",
+    skills: [
+      { name: "Figma / Sketch", pct: 80, level: "high" },
+      { name: "User Research", pct: 65, level: "high" },
+      { name: "Prototyping", pct: 70, level: "high" },
+      { name: "Front-end basics", pct: 35, level: "low" },
+      { name: "Data Analysis", pct: 40, level: "low" }
+    ],
+    nodes: ["Figma", "UX Research", "Prototyping", "Typography", "Motion", "Wireframing", "Branding"]
+  },
+  "Data Analyst": {
+    icon: "📊", score: 63,
+    tags: ["Python", "SQL", "Tableau"],
+    salary: "$55k – $95k", growth: "25% Growth", demand: "High",
+    skills: [
+      { name: "Python / R", pct: 75, level: "high" },
+      { name: "SQL", pct: 82, level: "high" },
+      { name: "Data Visualisation", pct: 60, level: "medium" },
+      { name: "Statistics", pct: 55, level: "medium" },
+      { name: "Machine Learning", pct: 30, level: "low" }
+    ],
+    nodes: ["Python", "SQL", "Pandas", "Tableau", "Statistics", "Excel", "Power BI"]
+  },
+  "Backend Developer": {
+    icon: "⚙️", score: 54,
+    tags: ["Node.js", "Databases", "APIs"],
+    salary: "$72k – $130k", growth: "20% Growth", demand: "Very High",
+    skills: [
+      { name: "Node.js / Python", pct: 80, level: "high" },
+      { name: "Databases (SQL/NoSQL)", pct: 70, level: "high" },
+      { name: "API Design", pct: 65, level: "medium" },
+      { name: "DevOps / Cloud", pct: 40, level: "low" },
+      { name: "Security", pct: 35, level: "low" }
+    ],
+    nodes: ["Node.js", "PostgreSQL", "MongoDB", "Docker", "REST", "AWS", "Redis"]
+  }
+};
+
+// Read career scores from localStorage (set by quiz-assessment.js) or use defaults
+function getCareerScores() {
+  try {
+    const stored = localStorage.getItem("quizCareerScores");
+    if (stored) return JSON.parse(stored);
+  } catch (e) {}
+  // Fallback to hardcoded defaults
+  return [
+    { name: "Frontend Engineer",  score: 91 },
+    { name: "Product Designer",   score: 78 },
+    { name: "Data Analyst",       score: 63 },
+    { name: "Backend Developer",  score: 54 }
+  ];
+}
+
+const careers = getCareerScores().map(c => ({
+  ...c,
+  ...(CAREER_DATA[c.name] || { icon: "🔭", tags: [], salary: "Varies", growth: "Growing", demand: "Moderate", skills: [], nodes: [] })
+}));
+
+const topCareer = careers[0];
+
+// ── HELPERS ──
+function showToast(msg) {
+  const t = document.getElementById("toast");
+  if (!t) return;
+  t.textContent = msg;
+  t.classList.add("show");
+  setTimeout(() => t.classList.remove("show"), 2800);
+}
+
+// ════════════════════════════════
+// HERO RING ANIMATION
+// ════════════════════════════════
+function animateRing(targetPct) {
+  const circle = document.getElementById("ring-progress");
+  const pctEl  = document.getElementById("match-pct");
+  if (!circle || !pctEl) return;
+  const circumference = 502;
+  const offset = circumference - (targetPct / 100) * circumference;
+  let current = 0;
+  const step = () => {
+    current = Math.min(current + 1.5, targetPct);
+    pctEl.textContent = Math.round(current) + "%";
+    circle.style.strokeDashoffset = circumference - (current / 100) * circumference;
+    if (current < targetPct) requestAnimationFrame(step);
+  };
+  setTimeout(() => requestAnimationFrame(step), 400);
+}
+
+// ── SET HERO ──
+function initHero() {
+  const pill = document.getElementById("top-career-pill");
+  document.getElementById("pill-icon").textContent  = topCareer.icon;
+  document.getElementById("pill-name").textContent  = topCareer.name;
+  const sub = document.getElementById("hero-sub");
+  if (sub) sub.textContent = `Based on your answers, our AI matched you to ${careers.length} career paths — here's where you shine.`;
+  animateRing(topCareer.score);
+}
+
+// ════════════════════════════════
+// CAREER CARDS
+// ════════════════════════════════
+function buildCareerCards() {
+  const grid = document.getElementById("careers-grid");
+  if (!grid) return;
+  grid.innerHTML = "";
+  careers.forEach((c, i) => {
+    const isPrimary = i === 0 ? "primary" : "";
+    const rankLabel = i === 0 ? "Best Match" : `#${i + 1} Match`;
+    const tagsHtml = (c.tags || []).map(t => `<span class="card-tag">${t}</span>`).join("");
+    const card = document.createElement("div");
+    card.className = `career-card ${isPrimary}`;
+    card.style.animationDelay = `${0.3 + i * 0.1}s`;
+    card.innerHTML = `
+      <div class="card-rank">${rankLabel}</div>
+      <div class="card-icon">${c.icon}</div>
+      <div class="card-title">${c.name}</div>
+      <div class="card-bar-wrap">
+        <div class="card-bar-bg"><div class="card-bar-fill" data-pct="${c.score}"></div></div>
+        <span class="card-pct">${c.score}%</span>
+      </div>
+      <div class="card-tags">${tagsHtml}</div>`;
+    grid.appendChild(card);
+  });
+
+  // Animate bars after a short delay
+  setTimeout(() => {
+    document.querySelectorAll(".card-bar-fill").forEach(el => {
+      el.style.width = el.dataset.pct + "%";
+    });
+  }, 500);
+}
+
+// ════════════════════════════════
+// STATS ROW
+// ════════════════════════════════
+function buildStats() {
+  document.getElementById("stat-salary-val").textContent = topCareer.salary  || "Varies";
+  document.getElementById("stat-growth-val").textContent = topCareer.growth  || "Growing";
+  document.getElementById("stat-demand-val").textContent = topCareer.demand  || "High";
+  document.getElementById("stat-score-val").textContent  = topCareer.score   + "%";
+}
+
+// ════════════════════════════════
+// SKILL BARS
+// ════════════════════════════════
+function buildSkillBars() {
+  const container = document.getElementById("skill-bars");
+  if (!container) return;
+  container.innerHTML = "";
+  (topCareer.skills || []).forEach(s => {
+    const row = document.createElement("div");
+    row.className = "skill-row";
+    row.innerHTML = `
+      <div class="skill-row-top">
+        <span class="skill-name">${s.name}</span>
+        <span class="skill-pct">${s.pct}%</span>
+      </div>
+      <div class="skill-track">
+        <div class="skill-fill ${s.level}" data-pct="${s.pct}"></div>
+      </div>`;
+    container.appendChild(row);
+  });
+  setTimeout(() => {
+    document.querySelectorAll(".skill-fill").forEach(el => {
+      el.style.width = el.dataset.pct + "%";
+    });
+  }, 600);
+}
+
+// ════════════════════════════════
+// CTA BUTTONS
+// ════════════════════════════════
+function buildCTA() {
+  const wrap = document.getElementById("cta-btns");
+  if (!wrap) return;
+  const isLoggedIn = !!localStorage.getItem("userEmail");
+  if (isLoggedIn) {
+    wrap.innerHTML = `
+      <a href="dashboard.html">
+        <button class="btn-gold" style="padding:13px 28px;font-size:14px">View Dashboard →</button>
+      </a>
+      <a href="quiz.html">
+        <button class="btn-outline" style="padding:12px 24px;font-size:14px">Retake Quiz</button>
+      </a>`;
+  } else {
+    wrap.innerHTML = `
+      <a href="login.html">
+        <button class="btn-gold" style="padding:13px 28px;font-size:14px">Sign in to Save Results →</button>
+      </a>
+      <a href="quiz.html">
+        <button class="btn-outline" style="padding:12px 24px;font-size:14px">Retake Quiz</button>
+      </a>`;
+  }
+}
+
+// ════════════════════════════════
+// PARTICLE BACKGROUND
+// ════════════════════════════════
+function initParticles() {
+  const canvas = document.getElementById("particles-canvas");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  let W, H, pts = [];
+
+  function resize() {
+    W = canvas.width  = window.innerWidth;
+    H = canvas.height = window.innerHeight;
+  }
+
+  function spawn() {
+    pts = Array.from({ length: 60 }, () => ({
+      x: Math.random() * W,
+      y: Math.random() * H,
+      r: Math.random() * 1.4 + 0.3,
+      vx: (Math.random() - 0.5) * 0.25,
+      vy: (Math.random() - 0.5) * 0.25,
+      a: Math.random() * 0.5 + 0.15
+    }));
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, W, H);
+    pts.forEach(p => {
+      p.x += p.vx; p.y += p.vy;
+      if (p.x < 0) p.x = W;
+      if (p.x > W) p.x = 0;
+      if (p.y < 0) p.y = H;
+      if (p.y > H) p.y = 0;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(212,175,55,${p.a})`;
+      ctx.fill();
+    });
+    // Draw faint connection lines
+    pts.forEach((a, i) => {
+      pts.slice(i + 1).forEach(b => {
+        const dx = a.x - b.x, dy = a.y - b.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < 120) {
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.strokeStyle = `rgba(212,175,55,${0.04 * (1 - dist / 120)})`;
+          ctx.lineWidth = 0.5;
+          ctx.stroke();
+        }
+      });
+    });
+    requestAnimationFrame(draw);
+  }
+  resize();
+  spawn();
+  draw();
+  window.addEventListener("resize", () => { resize(); spawn(); });
+}
+
+// ════════════════════════════════
+// 3D ECOSYSTEM CANVAS
+// ════════════════════════════════
+function initEcosystem() {
+  const canvas = document.getElementById("ecosystem-canvas");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+
+  // Match canvas resolution to CSS size
+  function resize() {
+    const rect = canvas.getBoundingClientRect();
+    canvas.width  = rect.width  * devicePixelRatio;
+    canvas.height = rect.height * devicePixelRatio;
+    ctx.scale(devicePixelRatio, devicePixelRatio);
+    CW = rect.width;
+    CH = rect.height;
+  }
+
+  let CW, CH;
+  resize();
+  window.addEventListener("resize", () => { resize(); buildNodes(); });
+
+  // Nodes
+  let nodes = [];
+  let rotX = 0.2, rotY = 0;
+  let isDragging = false, lastMX = 0, lastMY = 0;
+  let zoom = 1;
+  let animFrame;
+
+  function buildNodes() {
+    nodes = [];
+    const skillNames = topCareer.nodes || [];
+    const otherCareers = careers.slice(1).map(c => c.name);
+
+    // Center node (the user / top career)
+    nodes.push({ label: topCareer.name, icon: topCareer.icon, type: "center", x3: 0, y3: 0, z3: 0, r: 22 });
+
+    // Career nodes — orbit on a tilted ring
+    const cCount = Math.min(otherCareers.length, 3);
+    for (let i = 0; i < cCount; i++) {
+      const angle = (i / cCount) * Math.PI * 2;
+      const R = 160;
+      nodes.push({
+        label: careers[i + 1].name,
+        icon: careers[i + 1].icon,
+        type: "career",
+        x3: R * Math.cos(angle),
+        y3: R * Math.sin(angle) * 0.45,
+        z3: R * Math.sin(angle) * 0.88,
+        r: 15
+      });
+    }
+
+    // Skill nodes — further outer ring
+    const sCount = Math.min(skillNames.length, 7);
+    for (let i = 0; i < sCount; i++) {
+      const angle = (i / sCount) * Math.PI * 2 + 0.4;
+      const R = 260;
+      nodes.push({
+        label: skillNames[i],
+        type: "skill",
+        x3: R * Math.cos(angle),
+        y3: R * Math.sin(angle) * 0.35,
+        z3: R * Math.sin(angle) * 0.94,
+        r: 10
+      });
+    }
+  }
+
+  // Project 3D → 2D
+  function project(x3, y3, z3) {
+    // Rotate Y
+    const cosY = Math.cos(rotY), sinY = Math.sin(rotY);
+    const x1 = x3 * cosY - z3 * sinY;
+    const z1 = x3 * sinY + z3 * cosY;
+    // Rotate X
+    const cosX = Math.cos(rotX), sinX = Math.sin(rotX);
+    const y1 = y3 * cosX - z1 * sinX;
+    const z2 = y3 * sinX + z1 * cosX;
+    // Perspective
+    const fov = 600 * zoom;
+    const scale = fov / (fov + z2);
+    return {
+      x: CW / 2 + x1 * scale,
+      y: CH / 2 + y1 * scale,
+      s: scale,
+      z: z2
+    };
+  }
+
+  // Draw loop
+  function draw() {
+    ctx.clearRect(0, 0, CW, CH);
+
+    // Sort by z depth
+    const projected = nodes.map(n => ({
+      ...n,
+      proj: project(n.x3, n.y3, n.z3)
+    })).sort((a, b) => a.proj.z - b.proj.z);
+
+    // Draw edges first
+    projected.forEach(n => {
+      if (n.type === "center") return;
+      const center = projected.find(p => p.type === "center");
+      if (!center) return;
+      ctx.beginPath();
+      ctx.moveTo(center.proj.x, center.proj.y);
+      ctx.lineTo(n.proj.x, n.proj.y);
+      const alpha = n.type === "career" ? 0.18 : 0.1;
+      const color = n.type === "career" ? `rgba(212,175,55,${alpha})` : `rgba(100,180,255,${alpha})`;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = n.type === "career" ? 1 : 0.5;
+      ctx.setLineDash(n.type === "skill" ? [3, 5] : []);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    });
+
+    // Draw nodes
+    projected.forEach(n => {
+      const { x, y, s } = n.proj;
+      const r = n.r * s;
+
+      if (n.type === "center") {
+        // Glowing center
+        const grd = ctx.createRadialGradient(x, y, 0, x, y, r * 2.5);
+        grd.addColorStop(0, "rgba(212,175,55,0.25)");
+        grd.addColorStop(1, "rgba(212,175,55,0)");
+        ctx.beginPath(); ctx.arc(x, y, r * 2.5, 0, Math.PI * 2);
+        ctx.fillStyle = grd; ctx.fill();
+        ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.fillStyle = "rgba(212,175,55,0.15)";
+        ctx.strokeStyle = "rgba(212,175,55,0.8)";
+        ctx.lineWidth = 1.5; ctx.fill(); ctx.stroke();
+        // Icon
+        ctx.font = `${Math.max(10, 14 * s)}px sans-serif`;
+        ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        ctx.fillStyle = "#fff";
+        ctx.fillText(n.icon || "🎯", x, y);
+        // Label below
+        ctx.font = `500 ${Math.max(9, 11 * s)}px 'Playfair Display', serif`;
+        ctx.fillStyle = `rgba(212,175,55,${Math.min(1, 0.85 * s + 0.1)})`;
+        ctx.fillText(n.label, x, y + r + 14 * s);
+
+      } else if (n.type === "career") {
+        ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.fillStyle = "rgba(212,175,55,0.12)";
+        ctx.strokeStyle = `rgba(212,175,55,${0.5 * s + 0.2})`;
+        ctx.lineWidth = 1; ctx.fill(); ctx.stroke();
+        ctx.font = `${Math.max(8, 11 * s)}px sans-serif`;
+        ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        ctx.fillText(n.icon, x, y);
+        ctx.font = `${Math.max(8, 10 * s)}px sans-serif`;
+        ctx.fillStyle = `rgba(200,200,200,${Math.min(1, 0.7 * s + 0.1)})`;
+        ctx.fillText(n.label.split(" ")[0], x, y + r + 10 * s);
+
+      } else {
+        ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(100,180,255,${0.12 * s + 0.04})`;
+        ctx.strokeStyle = `rgba(100,180,255,${0.45 * s + 0.1})`;
+        ctx.lineWidth = 0.8; ctx.fill(); ctx.stroke();
+        ctx.font = `${Math.max(7, 9 * s)}px sans-serif`;
+        ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        ctx.fillStyle = `rgba(180,220,255,${Math.min(1, 0.8 * s + 0.05)})`;
+        ctx.fillText(n.label, x, y + r + 9 * s);
+      }
+    });
+
+    // Auto-rotate slowly
+    if (!isDragging) rotY += 0.003;
+    animFrame = requestAnimationFrame(draw);
+  }
+
+  // ── DRAG TO ROTATE ──
+  canvas.addEventListener("mousedown", e => {
+    isDragging = true;
+    lastMX = e.clientX; lastMY = e.clientY;
+  });
+  window.addEventListener("mousemove", e => {
+    if (!isDragging) return;
+    rotY += (e.clientX - lastMX) * 0.007;
+    rotX += (e.clientY - lastMY) * 0.007;
+    rotX = Math.max(-1, Math.min(1, rotX));
+    lastMX = e.clientX; lastMY = e.clientY;
+  });
+  window.addEventListener("mouseup", () => { isDragging = false; });
+
+  // Touch
+  canvas.addEventListener("touchstart", e => {
+    isDragging = true;
+    lastMX = e.touches[0].clientX;
+    lastMY = e.touches[0].clientY;
+  }, { passive: true });
+  canvas.addEventListener("touchmove", e => {
+    if (!isDragging) return;
+    rotY += (e.touches[0].clientX - lastMX) * 0.007;
+    rotX += (e.touches[0].clientY - lastMY) * 0.007;
+    rotX = Math.max(-1, Math.min(1, rotX));
+    lastMX = e.touches[0].clientX;
+    lastMY = e.touches[0].clientY;
+  }, { passive: true });
+  canvas.addEventListener("touchend", () => { isDragging = false; });
+
+  // Scroll to zoom
+  canvas.addEventListener("wheel", e => {
+    e.preventDefault();
+    zoom = Math.max(0.5, Math.min(2, zoom - e.deltaY * 0.001));
+  }, { passive: false });
+
+  buildNodes();
+  draw();
+}
+
+// ════════════════════════════════
+// INIT ALL
+// ════════════════════════════════
+document.addEventListener("DOMContentLoaded", () => {
+  initParticles();
+  initHero();
+  buildCareerCards();
+  buildStats();
+  buildSkillBars();
+  buildCTA();
+  // Ecosystem loads after a short delay to let layout settle
+  setTimeout(initEcosystem, 300);
+});

--- a/pages/quiz-results.html
+++ b/pages/quiz-results.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Your Career Match | PathwayAI</title>
+  <link rel="stylesheet" href="../assets/css/styles.css"/>
+  <link rel="stylesheet" href="../assets/css/quiz-results.css"/>
+</head>
+<body>
+
+<nav class="navbar">
+  <a href="../index.html" class="nav-logo">
+    <div class="logo-mark">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#0A0A0A" stroke-width="2.5" stroke-linecap="round">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+        <path d="M2 17l10 5 10-5"/>
+        <path d="M2 12l10 5 10-5"/>
+      </svg>
+    </div>
+    PathwayAI
+  </a>
+  <ul class="nav-links">
+    <li><a href="../index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="#">Features</a></li>
+  </ul>
+  <div class="nav-actions">
+    <a href="login.html"><button class="btn-gold">Sign in</button></a>
+  </div>
+</nav>
+
+<!-- Particle canvas background -->
+<canvas id="particles-canvas"></canvas>
+
+<main class="results-page">
+
+  <!-- ── HERO SECTION ── -->
+  <section class="results-hero" id="results-hero">
+    <div class="hero-glow-ring"></div>
+    <div class="hero-badge">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      Results Ready
+    </div>
+    <h1 class="hero-title">Your Perfect <em>Career Match</em></h1>
+    <p class="hero-sub" id="hero-sub">Based on your answers, our AI has mapped your strengths to the careers where you'll thrive most.</p>
+
+    <!-- Match score ring -->
+    <div class="match-ring-wrap">
+      <svg class="match-ring-svg" viewBox="0 0 200 200">
+        <circle cx="100" cy="100" r="80" fill="none" stroke="rgba(212,175,55,0.08)" stroke-width="12"/>
+        <circle cx="100" cy="100" r="80" fill="none" stroke="url(#ring-grad)"
+          stroke-width="12" stroke-linecap="round"
+          stroke-dasharray="502" stroke-dashoffset="502"
+          id="ring-progress" transform="rotate(-90 100 100)"/>
+        <defs>
+          <linearGradient id="ring-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stop-color="#D4AF37"/>
+            <stop offset="100%" stop-color="#F5D060"/>
+          </linearGradient>
+        </defs>
+      </svg>
+      <div class="match-ring-inner">
+        <span class="match-pct" id="match-pct">0%</span>
+        <span class="match-label">Top Match</span>
+      </div>
+    </div>
+
+    <!-- Top career pill -->
+    <div class="top-career-pill" id="top-career-pill">
+      <span class="pill-icon" id="pill-icon">💻</span>
+      <span class="pill-name" id="pill-name">Loading...</span>
+      <span class="pill-tag">Primary Match</span>
+    </div>
+  </section>
+
+  <!-- ── CAREER CARDS GRID ── -->
+  <section class="careers-section">
+    <div class="section-label">All Career Matches</div>
+    <h2 class="section-title">Your Career <em>Ecosystem</em></h2>
+    <p class="section-sub">Every path ranked by compatibility with your skills, interests, and work style</p>
+
+    <div class="careers-grid" id="careers-grid">
+      <!-- Injected by JS -->
+    </div>
+  </section>
+
+  <!-- ── 3D CAREER ECOSYSTEM ── -->
+  <section class="ecosystem-section">
+    <div class="section-label">Interactive Visualization</div>
+    <h2 class="section-title">Your Career <em>Network</em></h2>
+    <p class="section-sub">Explore how your top career connects to related roles and required skills</p>
+
+    <div class="ecosystem-wrap">
+      <canvas id="ecosystem-canvas"></canvas>
+      <div class="ecosystem-legend">
+        <div class="legend-item">
+          <span class="legend-dot dot-career"></span> Career paths
+        </div>
+        <div class="legend-item">
+          <span class="legend-dot dot-skill"></span> Key skills
+        </div>
+        <div class="legend-item">
+          <span class="legend-dot dot-center"></span> Your match
+        </div>
+      </div>
+      <div class="ecosystem-hint">Drag to rotate · Scroll to zoom</div>
+    </div>
+  </section>
+
+  <!-- ── STATS ROW ── -->
+  <section class="stats-section">
+    <div class="stat-card" id="stat-salary">
+      <div class="stat-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+      </div>
+      <div class="stat-value" id="stat-salary-val">$68k – $120k</div>
+      <div class="stat-name">Salary Range</div>
+    </div>
+    <div class="stat-card" id="stat-growth">
+      <div class="stat-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+      </div>
+      <div class="stat-value" id="stat-growth-val">22% Growth</div>
+      <div class="stat-name">Job Market Growth</div>
+    </div>
+    <div class="stat-card" id="stat-demand">
+      <div class="stat-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+      </div>
+      <div class="stat-value" id="stat-demand-val">High</div>
+      <div class="stat-name">Hiring Demand</div>
+    </div>
+    <div class="stat-card" id="stat-score">
+      <div class="stat-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+      </div>
+      <div class="stat-value" id="stat-score-val">91%</div>
+      <div class="stat-name">Compatibility Score</div>
+    </div>
+  </section>
+
+  <!-- ── SKILLS TO DEVELOP ── -->
+  <section class="skills-section">
+    <div class="skills-inner">
+      <div class="skills-left">
+        <div class="section-label">Skill Gap Analysis</div>
+        <h2 class="section-title" style="font-size:clamp(22px,3vw,32px)">Skills to <em>Develop</em></h2>
+        <p class="section-sub" style="margin-bottom:0">Focus on these areas to accelerate your path to your top career match.</p>
+      </div>
+      <div class="skills-right">
+        <div class="skill-bars" id="skill-bars">
+          <!-- Injected by JS -->
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── CTA ── -->
+  <section class="cta-section">
+    <div class="cta-card">
+      <div class="cta-glow"></div>
+      <div class="cta-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+      </div>
+      <h2 class="cta-title">Ready to Start Your Journey?</h2>
+      <p class="cta-sub">Save your results, explore colleges, and build your personalised career roadmap.</p>
+      <div class="cta-btns" id="cta-btns">
+        <!-- Injected by JS based on auth state -->
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<div id="toast" class="toast"></div>
+
+<script src="../assets/js/nav.js"></script>
+<script src="../assets/js/quiz-results.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What this PR does
- Adds a dedicated `quiz-results.html` page
- Adds `quiz-results.css` and `quiz-results.js`
- Updates `quiz-assessment.js`
- Replaces inline `showResult()` with localStorage + redirect flow

## Features included
- Animated career match ring
- Career cards with animated score bars and skill tags
- 3D career network visualization
- Stats row (salary, growth, demand, compatibility)
- Skill gap analysis bars
- Dynamic CTA based on login state
- Particle background matching theme

## Why this change
Improves UX by moving quiz results to a separate interactive page instead of inline rendering.

## Testing done
- Quiz submits successfully
- Data saved in localStorage
- Redirect to `quiz-results.html` works
- Results display correctly
- CTA works for both logged-in and logged-out users